### PR TITLE
prefer SetColor(black) outside the Close() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,10 @@ func main() {
             fmt.Println(err)
             continue
         }
-        defer dev.Close()
+        defer func() {
+            dev.SetColor(color.Black)
+            dev.Close()
+        }()
         dev.SetColor(RED)
 
         time.Sleep(2 * time.Second) // Wait 2 seconds because the device will turn off once it is closed!

--- a/blink1.go
+++ b/blink1.go
@@ -29,6 +29,5 @@ func (d *blink1Dev) SetColor(c color.Color) error {
 	return d.dev.WriteFeature([]byte{0x01, 0x63, byte(r >> 8), byte(g >> 8), byte(b >> 8), 0x00, 0x00, 0x00, 0x00})
 }
 func (d *blink1Dev) Close() {
-	d.SetColor(color.Black)
 	d.dev.Close()
 }

--- a/blinkm.go
+++ b/blinkm.go
@@ -29,6 +29,5 @@ func (d *blinkMDev) SetColor(c color.Color) error {
 	return d.dev.WriteFeature([]byte{0x01, 0xDA, 0x01, 0x05, 0x00, 0x09, 0x6E, byte(r >> 8), byte(g >> 8), byte(b >> 8)})
 }
 func (d *blinkMDev) Close() {
-	d.SetColor(color.Black)
 	d.dev.Close()
 }

--- a/blinkstick.go
+++ b/blinkstick.go
@@ -29,6 +29,5 @@ func (d *blinkStickDev) SetColor(c color.Color) error {
 	return d.dev.WriteFeature([]byte{0x01, byte(r >> 8), byte(g >> 8), byte(b >> 8)})
 }
 func (d *blinkStickDev) Close() {
-	d.SetColor(color.Black)
 	d.dev.Close()
 }

--- a/blync.go
+++ b/blync.go
@@ -55,6 +55,5 @@ func (d *blyncDev) SetColor(c color.Color) error {
 }
 
 func (d *blyncDev) Close() {
-	d.SetColor(color.Black)
 	d.dev.Close()
 }

--- a/busylight.go
+++ b/busylight.go
@@ -60,7 +60,6 @@ func newBusyLight(d hid.Device, setcolorFn func(c color.Color)) *busylightDev {
 				setcolorFn(curColor)
 			case <-closeChan:
 				ticker.Stop()
-				setcolorFn(color.Black) // turn off device
 				d.Close()
 				closed = true
 			}

--- a/dealextreme.go
+++ b/dealextreme.go
@@ -39,6 +39,5 @@ func (d *dealExtremeDev) SetColor(c color.Color) error {
 	return d.dev.Write([]byte{0x00, byte(palette.Index(c))})
 }
 func (d *dealExtremeDev) Close() {
-	d.SetColor(color.Black)
 	d.dev.Close()
 }

--- a/dreamcheeky.go
+++ b/dreamcheeky.go
@@ -36,6 +36,5 @@ func (d *dreamCheekyDev) SetColor(c color.Color) error {
 	return d.dev.Write([]byte{0x00, byte(r >> 10), byte(g >> 10), byte(b >> 10), 0x00, 0x00, 0x54, 0x2C, 0x05})
 }
 func (d *dreamCheekyDev) Close() {
-	d.SetColor(color.Black)
 	d.dev.Close()
 }


### PR DESCRIPTION
I'm working on a command line tool, that is able to control LEDs, using your library.
As it is a command line tool, it's expected that setting a color is durable even after the process has finished. Currently the led lib sets the color to Black, when the resources are freed/closed.

That's why I've pulled the SetColor(color.Black) call out of the Close() method.
I think this is better because:

* Close() only frees bound resources
* Close() doesn't have any behavior on the LED
* It powers more freedom to the library users

I'm aware that this changes current behavior. That's why I've added some detail in README file.

Any thoughts/feedback?